### PR TITLE
fix issue #1: increment pot size by 3 instead of 1

### DIFF
--- a/src/pages/components/Button.js
+++ b/src/pages/components/Button.js
@@ -6,6 +6,7 @@ export default function Button(props) {
     bgColor = 'white',
     textColor = 'black',
     borderColor = 'gray-400',
+    isDisabled = false,
   } = props;
 
   if (width !== 'auto' && width !== 'fixed') {
@@ -15,10 +16,10 @@ export default function Button(props) {
 
   return (
     <div
-      onClick={onClick}
-      className={`${
-        width === 'fixed' ? 'w-7 h-7' : 'px-9 py-2 text-xs'
-      } font-semibold cursor-pointer rounded-full bg-${bgColor} text-${textColor} border border-${borderColor} inline-block self-center text-center`}
+      onClick={!isDisabled ? onClick : null}
+      className={`${width === 'fixed' ? 'w-7 h-7' : 'px-9 py-2 text-xs'} ${
+        isDisabled ? 'bg-gray-300' : 'cursor-pointer'
+      } font-semibold rounded-full bg-${bgColor} text-${textColor} border border-${borderColor} inline-block self-center text-center`}
     >
       {title}
     </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -147,9 +147,10 @@ export default function Home() {
                       bgColor="orange-400"
                       textColor="white"
                       borderColor="white"
+                      isDisabled={potSize === 15}
                       onClick={() =>
                         setPotSize((prevPotSize) =>
-                          Math.max(prevPotSize - 3, 0)
+                          Math.max(prevPotSize - 3, 15)
                         )
                       }
                     />
@@ -162,9 +163,10 @@ export default function Home() {
                       bgColor="orange-400"
                       textColor="white"
                       borderColor="white"
+                      isDisabled={potSize === 81}
                       onClick={() =>
                         setPotSize((prevPotSize) =>
-                          Math.min(prevPotSize + 3, 999)
+                          Math.min(prevPotSize + 3, 81)
                         )
                       }
                     />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -149,7 +149,7 @@ export default function Home() {
                       borderColor="white"
                       onClick={() =>
                         setPotSize((prevPotSize) =>
-                          Math.max(prevPotSize - 1, 0)
+                          Math.max(prevPotSize - 3, 0)
                         )
                       }
                     />
@@ -164,7 +164,7 @@ export default function Home() {
                       borderColor="white"
                       onClick={() =>
                         setPotSize((prevPotSize) =>
-                          Math.min(prevPotSize + 1, 999)
+                          Math.min(prevPotSize + 3, 999)
                         )
                       }
                     />


### PR DESCRIPTION
fix issue #1: in the game you can only increase the pot size by 3, match the behavior on the website

it seems that minimum pot size = 15, maximum pot size = 81, so i've limited the value to be between those values, and disabled the button at each end ([source](https://www.serebii.net/pokemonsleep/dishes.shtml))

### After

https://github.com/skinsshark/pokemon-eat/assets/13009769/5fdda605-193a-43ec-98f6-1a65ebd2062d

### Before

https://github.com/skinsshark/pokemon-eat/assets/13009769/9cfb0dcf-d3a8-47c1-b872-51a02b81c6ee



